### PR TITLE
fix runtime failure on mac os

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -15,7 +15,20 @@
         "<!@(pkg-config --libs opencv)",
         "-L/usr/local/cuda-6.0/lib64"
       ],
-      "defines": [
+      "conditions": [
+        ['OS=="mac"', {
+          # cflags on OS X are stupid and have to be defined like this
+          'xcode_settings': {
+            'OTHER_CFLAGS': [
+                "-mmacosx-version-min=10.7",
+                "-std=c++11",
+                "-stdlib=libc++",
+              '<!@(pkg-config --cflags opencv)'
+            ]
+            , "GCC_ENABLE_CPP_RTTI": "YES"
+            , "GCC_ENABLE_CPP_EXCEPTIONS": "YES"
+          }
+        }]
       ]
     }
   ]


### PR DESCRIPTION
I got this error on `npm test` on mac os

```
  TidalWave
request: /Users/soichi/git/tidal-wave/test/fixture/expected/scenario1/capture1.jpg <-> /Users/soichi/git/tidal-wave/test/fixture/revision1/scenario1/capture1.jpg
request: /Users/soichi/git/tidal-wave/test/fixture/expected/scenario2/capture2.png <-> /Users/soichi/git/tidal-wave/test/fixture/revision1/scenario2/capture2.png
consume: /Users/soichi/git/tidal-wave/test/fixture/expected/scenario1/capture1.jpg <-> /Users/soichi/git/tidal-wave/test/fixture/revision1/scenario1/capture1.jpg
dyld: lazy symbol binding failed: Symbol not found: __ZN2cv6imreadERKSsi
  Referenced from: /Users/soichi/git/tidal-wave/build/Release/tidalwave.node
  Expected in: flat namespace

dyld: Symbol not found: __ZN2cv6imreadERKSsi
  Referenced from: /Users/soichi/git/tidal-wave/build/Release/tidalwave.node
  Expected in: flat namespace

consume: /Users/soichi/git/tidal-wave/test/fixture/expected/scenario2/capture2.png <-> /Users/soichi/git/tidal-wave/test/fixture/revision1/scenario2/capture2.png
dyld: lazy symbol binding failed: Symbol not found: __ZN2cv6imreadERKSsi
  Referenced from: /Users/soichi/git/tidal-wave/build/Release/tidalwave.node
  Expected in: flat namespace

dyld: Symbol not found: __ZN2cv6imreadERKSsi
  Referenced from: /Users/soichi/git/tidal-wave/build/Release/tidalwave.node
  Expected in: flat namespace

Trace/BPT trap: 5
```

This saved us. https://github.com/peterbraden/node-opencv/commit/f66364f1bbf8b2763b9af3204bd0cc7a4729dcde
